### PR TITLE
Исправлен healthcheck: добавлена проверка HTTP-статуса через raise_fo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ EXPOSE 8000
 
 # Healthcheck
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD python -c "import httpx; httpx.get('http://localhost:8000/health', timeout=5.0)" || exit 1
+  CMD python -c "import httpx; httpx.get('http://localhost:8000/health', timeout=5.0).raise_for_status()" || exit 1
 
 # Запуск в HTTP режиме
 ENTRYPOINT ["python", "-m", "src.py_server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - .env
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/health', timeout=5.0)"]
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/health', timeout=5.0).raise_for_status()"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
…r_status()

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Docker and Compose healthchecks to fail on non-2xx by calling httpx.get(...).raise_for_status().
> 
> - **Healthchecks**:
>   - `Dockerfile`: use `httpx.get(...).raise_for_status()` in `HEALTHCHECK` command.
>   - `docker-compose.yml`: update `healthcheck.test` to call `raise_for_status()` as well.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd9f8891b6089ae00f2ee316041ed20488fd1922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->