### PR TITLE
fix: healthcheck возвращает 503 при недо��тупности 1С

### DIFF
--- a/src/py_server/http_server.py
+++ b/src/py_server/http_server.py
@@ -332,24 +332,40 @@ class MCPHttpServer:
 		async def health():
 			"""Проверка здоровья сервера."""
 			try:
-				# Проверяем подключение к 1С через прокси
+				# Проверяем подключение к 1С
+				# Используем существующий клиент сессии, если есть, иначе создаём временный
 				if hasattr(self.mcp_proxy, 'onec_client') and self.mcp_proxy.onec_client:
 					await self.mcp_proxy.onec_client.check_health()
-					result = {"status": "healthy", "onec_connection": "ok"}
+				elif self.config.onec_username and self.config.onec_password:
+					# Нет активной сессии — проверяем 1С напрямую через временный клиент
+					from .onec_client import OneCClient
+					temp_client = OneCClient(
+						base_url=self.config.onec_url,
+						username=self.config.onec_username,
+						password=self.config.onec_password,
+						service_root=self.config.onec_service_root
+					)
+					try:
+						await temp_client.check_health()
+					finally:
+						await temp_client.close()
 				else:
-					result = {"status": "starting", "onec_connection": "not_initialized"}
-				
-				# Добавляем информацию об авторизации
-				result["auth"] = {"mode": self.config.auth_mode}
-				return result
+					# OAuth2 режим без активной сессии — можем проверить только сам прокси
+					return {"status": "healthy", "onec_connection": "not_checked_no_session", "auth": {"mode": self.config.auth_mode}}
+
+				return {"status": "healthy", "onec_connection": "ok", "auth": {"mode": self.config.auth_mode}}
 			except Exception as e:
-				logger.error(f"Ошибка проверки здоровья: {e}")
-				return {
-					"status": "unhealthy",
-					"onec_connection": "error",
-					"error_details": str(e),
-					"auth": {"mode": self.config.auth_mode}
-				}
+				error_detail = f"{type(e).__name__}: {str(e) or repr(e)}"
+				logger.error(f"Ошибка проверки здоровья: {error_detail}")
+				return JSONResponse(
+					status_code=503,
+					content={
+						"status": "unhealthy",
+						"onec_connection": "error",
+						"error_details": error_detail,
+						"auth": {"mode": self.config.auth_mode}
+					}
+				)
 		
 		# OAuth2 endpoints (если включено)
 		if self.config.auth_mode == "oauth2":

--- a/src/py_server/onec_client.py
+++ b/src/py_server/onec_client.py
@@ -84,7 +84,7 @@ class OneCClient:
 				raise httpx.HTTPStatusError(f"Invalid JSON response from 1C health check: {e}", request=response.request, response=response)
 
 		except httpx.HTTPError as e:
-			logger.error(f"Ошибка HTTP при проверке состояния 1С: {e}")
+			logger.error(f"Ошибка HTTP при проверке состояния 1С: {type(e).__name__}: {str(e) or repr(e)}")
 			raise
 	
 	async def call_rpc(self, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- `/health` endpoint теперь проверяет подключение к 1С даже без активной MCP-сессии (создаёт временный `OneCClient`)
- При недоступности 1С возвращает **HTTP 503** вместо 200 с JSON-ошибкой — Docker healthcheck корректно определяет `unhealthy`
- Исправлено логирование о��ибок `httpx.ReadTimeout` — `str()` таких исключений возвращает пустую строку, теперь выводится тип и `repr`

## Проблема
1. `onec_client` создавался только при установлении MCP-сессии (в `_lifespan`), поэтому `/health` никогда не тестировал 1С до первого подключения клиента — всегда возвращал `"not_initialized"`
2. `/health` возвращал HTTP 200 даже при ошибке подключения к 1С, из-за чего Docker healthcheck ложно показывал контейнер как `healthy`
3. `str(httpx.ReadTimeout())` возвращает пустую строку — в логах ошибки были без описания

## Test plan
- [ ] Запустить контейнер без доступного сервера 1С — `/health` должен вернуть 503
- [ ] Запустить с доступным 1С — `/health` должен вернуть 200 с `"onec_connection": "ok"`
- [ ] Docker healthcheck должен показать `unhealthy` при недоступной 1С
- [ ] В режиме `auth_mode=oauth2` без сессии `/health` возвращает 200 с `"not_checked_no_session"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)