### PR TITLE
feat(1c_ext): инфраструктурная подсистема для интеграции с client_mcp (DRIVE)

### DIFF
--- a/src/1c_ext/Configuration.xml
+++ b/src/1c_ext/Configuration.xml
@@ -64,6 +64,7 @@
 		<ChildObjects>
 			<Language>Русский</Language>
 			<Subsystem>mcp_MCPСервер</Subsystem>
+			<Subsystem>mcp_Мсп_Провайдеры</Subsystem>
 			<Role>mcp_ОсновнаяРоль</Role>
 			<CommonModule>mcp_ОбщегоНазначения</CommonModule>
 			<CommonModule>mcp_КонтейнерыПовтИсп</CommonModule>

--- a/src/1c_ext/Subsystems/mcp_Мсп_Провайдеры.xml
+++ b/src/1c_ext/Subsystems/mcp_Мсп_Провайдеры.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:app="http://v8.1c.ru/8.2/managed-application/core" xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config" xmlns:cmi="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:ent="http://v8.1c.ru/8.1/data/enterprise" xmlns:lf="http://v8.1c.ru/8.2/managed-application/logform" xmlns:style="http://v8.1c.ru/8.1/data/ui/style" xmlns:sys="http://v8.1c.ru/8.1/data/ui/fonts/system" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:v8ui="http://v8.1c.ru/8.1/data/ui" xmlns:web="http://v8.1c.ru/8.1/data/ui/colors/web" xmlns:win="http://v8.1c.ru/8.1/data/ui/colors/windows" xmlns:xen="http://v8.1c.ru/8.3/xcf/enums" xmlns:xpr="http://v8.1c.ru/8.3/xcf/predef" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Subsystem uuid="05640725-02aa-44e1-be6b-d2b053c4c6ac">
+		<Properties>
+			<Name>mcp_Мсп_Провайдеры</Name>
+			<Synonym>
+				<v8:item>
+					<v8:lang>en</v8:lang>
+					<v8:content>MCP providers (mcp_tools)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>ru</v8:lang>
+					<v8:content>Провайдеры MCP (mcp_tools)</v8:content>
+				</v8:item>
+				<v8:item>
+					<v8:lang>tr</v8:lang>
+					<v8:content>MCP providers (mcp_tools)</v8:content>
+				</v8:item>
+			</Synonym>
+			<Comment/>
+			<IncludeHelpInContents>true</IncludeHelpInContents>
+			<IncludeInCommandInterface>false</IncludeInCommandInterface>
+			<UseOneCommand>false</UseOneCommand>
+			<Explanation/>
+			<Picture/>
+			<Content/>
+		</Properties>
+		<ChildObjects/>
+	</Subsystem>
+</MetaDataObject>


### PR DESCRIPTION
## Summary

Добавляет подсистему-маркер `mcp_Мсп_Провайдеры` в расширение `MCP_Сервер` — инфраструктурную точку для интеграции с расширением [`client_mcp`](https://github.com/1c-neurofish/v8-session-manager) (BSL-клиент менеджера сессий 1С). client_mcp при старте сканирует свою конфигурацию в поисках подсистем с таким именем и регистрирует их содержимое в реестре MCP-клиента.

### Что внутри

| Файл | Что |
|---|---|
| `src/1c_ext/Subsystems/mcp_Мсп_Провайдеры.xml` | Новая пустая подсистема-маркер (ru/en/tr-синонимы, `IncludeInCommandInterface=false`) |
| `src/1c_ext/Configuration.xml` | +1 строка: ссылка на новую подсистему в `ChildObjects` |

**Только инфраструктура — никакого автоматического проброса tools.** Подсистема пустая. Если пользователь захочет открыть какие-либо инструменты MCP-клиенту — добавляет в эту подсистему свой общий модуль с интерфейсом `ОписанияИнструментов()` / `ВыполнитьИнструмент()`. Это сознательный выбор: на расширение, которое контролирует доступ к данным, не должны навязываться tools (включая query/execute) без явного решения автора.

### Не входит в этот PR

- Прикладные провайдеры с пробросом конкретных tools (metadata/query/etc.) — отдельная история, по решению владельца расширения.

### Test plan

- [x] Расширение собирается в Конфигураторе.
- [x] Структура подсистемы — пустая, не влияет на runtime до явного добавления модулей.

🤖 Generated with [Claude Code](https://claude.com/claude-code)