### PR TITLE
Ошибка при работе в докере с MCP SDK 2

### DIFF
--- a/src/py_server/requirements.txt
+++ b/src/py_server/requirements.txt
@@ -4,4 +4,4 @@ httpx>=0.27.0
 pydantic>=2.5.0
 pydantic-settings>=2.0.0
 python-dotenv>=1.0.0
-mcp>=1.8.0 
+mcp>=1.8.0,<2.0.0


### PR DESCRIPTION
MCP SDK 2.0 сильно изменилась, обновил файл зависимостей

https://github.com/vladimir-kharin/1c_mcp/issues/25