### PR TITLE
fix: pin mcp to >=1.8.0,<2.0.0 to avoid breaking changes in SDK v2

### DIFF
--- a/src/py_server/requirements.txt
+++ b/src/py_server/requirements.txt
@@ -4,4 +4,4 @@ httpx>=0.27.0
 pydantic>=2.5.0
 pydantic-settings>=2.0.0
 python-dotenv>=1.0.0
-mcp>=1.8.0 
+mcp>=1.8.0,<2.0.0 


### PR DESCRIPTION
## Проблема

При установке последней версии библиотеки `mcp` (v2.x) сервер падает при запуске с ошибкой:

```
src.py_server.main - ERROR - Критическая ошибка: 'Server' object has no attribute 'list_tools'
```

## Причина

В SDK `mcp` **второй версии** произошли breaking changes: метод `list_tools` был удалён с объекта `Server` (изменился механизм регистрации и перечисления инструментов). Так как в `requirement.txt` указано неограниченное `mcp>=1.8.0`, pip ставит последнюю версию 2.x, которая несовместима с текущим кодом `src/py_server`.

## Решение

Зафиксировать версию библиотеки в `src/py_server/requirements.txt`, ограничив её первой мажорной версией:

`mcp>=1.8.0,<2.0.0`

Это гарантирует установку только совместимой линейки 1.x. После переноса кода на v2 API ограничение можно будет снять.

## Проверка

- [x] Сервер запускается без ошибки `'Server' object has no attribute 'list_tools'`
